### PR TITLE
Fix typo tabs

### DIFF
--- a/resources/views/modules/default/edit/form.blade.php
+++ b/resources/views/modules/default/edit/form.blade.php
@@ -17,7 +17,7 @@
         @section('default-tabs')
         <div class="row">
             @foreach($module->tabs as $tab_i => $tab)
-            <div id="#tab{{ $tab_i }}" class="col s12">
+            <div id="tab{{ $tab_i }}" class="col s12">
                 @foreach ($tab->blocks as $block_i => $block)
                 <div class="card">
                     <div class="card-content">


### PR DESCRIPTION
Typo : tabs not working because of wrong div name (was including '#')