### PR TITLE
Assigned user list filtered or not depending on config

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -685,31 +685,30 @@ class User extends Authenticatable implements Searchable
             'recordLabel' => uctrans('me', $this->module)
         ]]);
 
-        // if ($this->is_admin) {
-        $groups = Group::inDomain($domain)->orderBy('name')->get();
-        $users  = \App\User::inDomain($domain)->orderBy('name')->get();
-        // } else {
-        //     $groups = [];
-        //     $users = [];
+        if (!config('uccello.users.assigned_user_filter_users_groups') || $this->is_admin) {
+            $groups = Group::inDomain($domain)->orderBy('name')->get();
+            $users  = \App\User::inDomain($domain)->orderBy('name')->get();
+        } else {
+            $groups = [];
+            $users = [];
 
-        //     foreach ($this->groups as $group) {
-        //         $groups[$group->uuid] = $group;
+            foreach ($this->groups as $group) {
+                $groups[$group->uuid] = $group;
 
-        //         if($addUsers)
-        //         {
-        //             foreach ($group->users as $user) {
-        //                 if (empty($users[$user->uuid])) {
-        //                     $users[$user->uuid] = $user;
-        //                 }
-        //             }
-        //         }
-        //     };
+                if ($addUsers) {
+                    foreach ($group->users as $user) {
+                        if (empty($users[$user->uuid])) {
+                            $users[$user->uuid] = $user;
+                        }
+                    }
+                }
+            };
 
-        //     $this->addRecursiveChildrenGroups($groups, $users, $groups, $addUsers);
+            $this->addRecursiveChildrenGroups($groups, $users, $groups, $addUsers);
 
-        //     $groups = collect($groups)->sortBy('name');
-        //     $users  = collect($users)->sortBy('name');
-        // }
+            $groups = collect($groups)->sortBy('name');
+            $users  = collect($users)->sortBy('name');
+        }
 
         foreach ($groups as $uuid => $group) {
             $allowedUserUuids[] = [

--- a/config/uccello.php
+++ b/config/uccello.php
@@ -64,7 +64,7 @@ return [
 
         // If true, any Uitype *AssignedUser* will display a filtered list of users and groups.
         // Else, all groups and users will be displayed
-        'assigned_user_filter_users_groups' => false,
+        'assigned_user_filter_users_groups' => true,
     ],
 
     'entity' => [

--- a/config/uccello.php
+++ b/config/uccello.php
@@ -61,6 +61,10 @@ return [
 
         // If true, all admin users will be shown in the users list.
         'display_all_admin_users' => false,
+
+        // If true, any Uitype *AssignedUser* will display a filtered list of users and groups.
+        // Else, all groups and users will be displayed
+        'assigned_user_filter_users_groups' => false,
     ],
 
     'entity' => [


### PR DESCRIPTION
Depending on the needs, an uitype "Assigned user" should be able to display all users and groups, or only the ones I have access (groups).
`config('ucccello.users.assigned_user_filter_users_groups')` will let me choose